### PR TITLE
Explicite la valeur de on_delete dans les migrations

### DIFF
--- a/parrainage/app/migrations/0003_auto_20170214_1119.py
+++ b/parrainage/app/migrations/0003_auto_20170214_1119.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='note',
             name='elu',
-            field=models.ForeignKey(to='app.Elu', related_name='notes'),
+            field=models.ForeignKey(to='app.Elu', related_name='notes', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='note',

--- a/parrainage/app/migrations/0004_usersettings.py
+++ b/parrainage/app/migrations/0004_usersettings.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('phone', models.CharField(max_length=255, blank=True)),
                 ('city', models.CharField(max_length=255, blank=True)),
                 ('department', models.CharField(db_index=True, max_length=3, blank=True)),
-                ('user', models.OneToOneField(related_name='settings', to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(related_name='settings', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
     ]


### PR DESCRIPTION
Cela permet de supprimer un message d’avertissement qui prévient que ce sera nécessaire à partir de Django 2.0.