### PR TITLE
S’assure que les coordonnées de mairies sont uniques

### DIFF
--- a/parrainage/app/management/commands/import_maires.py
+++ b/parrainage/app/management/commands/import_maires.py
@@ -10,6 +10,7 @@ from django.db import transaction
 import pandas as pd
 
 from parrainage.app.models import Elu
+from parrainage.app.sources.annuaire import nettoie_mairies
 from parrainage.app.sources.rne import parse_elu
 
 
@@ -40,9 +41,10 @@ class Command(BaseCommand):
 def merge_csv(tsv_maires, csv_mairies):
     df = pd.merge(
         pd.read_csv(tsv_maires, sep="\t", dtype=str),
-        pd.read_csv(csv_mairies, sep=",", dtype=str),
+        nettoie_mairies(pd.read_csv(csv_mairies, sep=",", dtype=str)),
         left_on="Code de la commune",
         right_on="codeInsee",
+        validate="one_to_one",
     )
     df.fillna("", inplace=True)
     for _, row in df.iterrows():

--- a/parrainage/app/sources/annuaire.py
+++ b/parrainage/app/sources/annuaire.py
@@ -1,19 +1,8 @@
-import csv
-
-from parrainage.app.models import Elu
-
-
-def read_csv(iterable):
-    return csv.DictReader(iterable, delimiter=",")
-
-
-def met_a_jour_coordonnees_elus(row_annuaire):
-    for elu in Elu.objects.filter(city_code=row_annuaire["codeInsee"]):
-        elu.public_email = row_annuaire["Email"]
-        elu.public_phone = row_annuaire["Téléphone"]
-        elu.public_website = row_annuaire["Url"]
-        elu.city_address = row_annuaire["Adresse"]
-        elu.city_zipcode = row_annuaire["CodePostal"]
-        elu.city_latitude = row_annuaire["Latitude"]
-        elu.city_longitude = row_annuaire["Longitude"]
-        elu.save()
+def nettoie_mairies(df):
+    df.sort_values("codeInsee", inplace=True)
+    return df[
+        df["NomOrganisme"].str.contains("Mairie")
+        & ~df["NomOrganisme"].str.contains("Mairie déléguée")
+        & ~df["NomOrganisme"].str.contains("Mairie  déléguée")
+        & ~df.duplicated(subset=["codeInsee"])
+    ]


### PR DESCRIPTION
Plusieurs codes Insee ont plusieurs coordonnées de mairies dans l’annuaire. Par conséquent, la jointure n’était pas 1:1 et cela conduisait à dupliquer les élus en base.

On ne garde que les mairies (il y a des « Point d’information ») et on supprime les mairies déléguées. Si des doublons persistent, on ne conserve que la première entrée.