### PR TITLE
Ajoute l’import des membres du Conseil de Paris

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ wget --content-disposition https://www.data.gouv.fr/fr/datasets/r/601ef073-d986-
 python manage.py import_elus --mandat=CD rne-cd.csv
 ```
 
+#### Liste des conseillers de Paris
+
+- Récupérer `rne-cm.csv` depuis https://www.data.gouv.fr/fr/datasets/repertoire-national-des-elus-1/
+```
+wget --content-disposition https://www.data.gouv.fr/fr/datasets/r/d5f400de-ae3f-4966-8cb6-a85c70c6c24a
+```
+
+- Lancer la commande :
+```
+python manage.py import_elus --mandat=CP rne-cm.csv
+```
+
 #### Liste des conseillers régionaux
 
 - Récupérer `rne-cr.csv` depuis https://www.data.gouv.fr/fr/datasets/repertoire-national-des-elus-1/


### PR DESCRIPTION
Statut particulier, à la fois les responsabilités d’un conseil municipal et d’un
conseil départemental : on les importe depuis la liste des conseillers municipaux,
mais on les ajoute avec le rôle de conseillers départementaux.

Fixes #29