### PR TITLE
Ajoute le temps de réponse dans l’access log de gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn parrainage.project.wsgi --log-file -
+web: gunicorn parrainage.project.wsgi -c gunicorn_config.py
 postdeploy: python manage.py migrate && python manage.py create_initial_admin_user

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,0 +1,11 @@
+# https://docs.gunicorn.org/en/latest/settings.html#accesslog
+accesslog = "-"
+
+# https://docs.gunicorn.org/en/latest/settings.html#accesslog
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(M)s'
+
+# https://docs.gunicorn.org/en/latest/settings.html#errorlog
+errorlog = "-"
+
+# https://docs.gunicorn.org/en/latest/settings.html#timeout
+timeout = 30


### PR DESCRIPTION
On ajoute un fichier de config pour Gunicorn, où on explicite certains paramètres.